### PR TITLE
Add Admin /retrieve Earthquakes endpoint

### DIFF
--- a/.github/workflows/02-frontend-03-mutation-testing.yml
+++ b/.github/workflows/02-frontend-03-mutation-testing.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 40
 
     strategy:
       matrix:

--- a/src/main/java/edu/ucsb/cs156/example/collections/FeatureCollection.java
+++ b/src/main/java/edu/ucsb/cs156/example/collections/FeatureCollection.java
@@ -1,0 +1,12 @@
+package edu.ucsb.cs156.example.collections;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import edu.ucsb.cs156.example.documents.Feature;
+
+@Repository
+public interface FeatureCollection extends MongoRepository<Feature, ObjectId> {
+ 
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/EarthquakesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/EarthquakesController.java
@@ -3,6 +3,9 @@ package edu.ucsb.cs156.example.controllers;
 import org.springframework.web.bind.annotation.RestController;
 
 import edu.ucsb.cs156.example.services.EarthquakeQueryService;
+import edu.ucsb.cs156.example.collections.FeatureCollection;
+import edu.ucsb.cs156.example.documents.Feature;
+import edu.ucsb.cs156.example.documents.GeoJSON;
 import edu.ucsb.cs156.example.repositories.UserRepository;
 import lombok.extern.slf4j.Slf4j;
 
@@ -11,6 +14,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.util.List;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -31,17 +37,25 @@ public class EarthquakesController {
     UserRepository userRepository;
 
     @Autowired
+    FeatureCollection featureCollection;
+
+    @Autowired
     EarthquakeQueryService earthquakeQueryService;
 
-    @ApiOperation(value = "Get earthquakes a certain distance from UCSB's Storke Tower", notes = "JSON return format documented here: https://earthquake.usgs.gov/earthquakes/feed/v1.0/geojson.php")
-    @GetMapping("/get")
+    @ApiOperation(value = "Get earthquakes a certain distance from UCSB's Storke Tower and store the update in the MongoDB collection earthquakes", notes = "JSON return format documented here: https://earthquake.usgs.gov/earthquakes/feed/v1.0/geojson.php")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/retrieve")
     public ResponseEntity<String> getEarthquakes(
-        @ApiParam("distance in km, e.g. 100") @RequestParam String distance,
-        @ApiParam("minimum magnitude, e.g. 2.5") @RequestParam String minMag
-    ) throws JsonProcessingException {
-        log.info("getEarthquakes: distance={} minMag={}", distance, minMag);
-        String result = earthquakeQueryService.getJSON(distance, minMag);
+            @ApiParam("distance in km, e.g. 100") @RequestParam String distanceKm,
+            @ApiParam("minimum magnitude, e.g. 2.5") @RequestParam String minMagnitude
+        ) throws JsonProcessingException {
+        log.info("getEarthquakes: distance={} minMag={}", distanceKm, minMagnitude);
+        String result = earthquakeQueryService.getJSON(distanceKm, minMagnitude);
+        // Convert each earthquake to a feature object
+        GeoJSON json = mapper.readValue(result, GeoJSON.class);
+        List<Feature> features = json.getFeatures();
+        // Save each earthquake TO the collection
+        featureCollection.saveAll(features);
         return ResponseEntity.ok().body(result);
     }
-
 }

--- a/src/main/java/edu/ucsb/cs156/example/documents/Feature.java
+++ b/src/main/java/edu/ucsb/cs156/example/documents/Feature.java
@@ -1,0 +1,27 @@
+package edu.ucsb.cs156.example.documents;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Document("earthquakes")
+public class Feature {
+    @Id
+    private String id;
+
+    private FeatureProperties properties;
+    private FeatureGeometry geometry;
+}

--- a/src/main/java/edu/ucsb/cs156/example/documents/FeatureGeometry.java
+++ b/src/main/java/edu/ucsb/cs156/example/documents/FeatureGeometry.java
@@ -1,0 +1,20 @@
+package edu.ucsb.cs156.example.documents;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FeatureGeometry {
+    private List<Float> coordinates;
+}

--- a/src/main/java/edu/ucsb/cs156/example/documents/FeatureProperties.java
+++ b/src/main/java/edu/ucsb/cs156/example/documents/FeatureProperties.java
@@ -1,0 +1,42 @@
+package edu.ucsb.cs156.example.documents;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FeatureProperties {
+    private float mag;
+    private String place;
+    private long time;
+    private long updated;
+    private int tz;
+    private String url;
+    private String detail;
+    private int felt;
+    private float cdi;
+    private float mmi;
+    private String alert;
+    private String status;
+    private int tsunami;
+    private int sig;
+    private String net;
+    private String code;
+    private String ids;
+    private String sources;
+    private String types;
+    private int nst;
+    private float dmin;
+    private float rms;
+    private float gap;
+    private String magType;
+    private String type;
+}

--- a/src/main/java/edu/ucsb/cs156/example/documents/GeoJSON.java
+++ b/src/main/java/edu/ucsb/cs156/example/documents/GeoJSON.java
@@ -1,0 +1,20 @@
+package edu.ucsb.cs156.example.documents;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GeoJSON {
+    // Only care about the list of features
+    private List<Feature> features;
+}


### PR DESCRIPTION
In this PR we implement api/earthquakes/retrieve which when called by an admin will update the mongodb collection with an updated set of earthquakes from the USGS earthquakes endpoint